### PR TITLE
Fix the parse-tree reference leak in speedy-antlr-tool's support library

### DIFF
--- a/tools/gen_speedy_antlr.py
+++ b/tools/gen_speedy_antlr.py
@@ -121,6 +121,53 @@ CPP_PATCHES = [
 # tokenVocab: NmrViewNPKParser uses NmrViewPKLexer, and SparkyNPKParser and
 # SparkyRPKParser use SparkyPKLexer. Without this the generated C++ fails to
 # compile on a missing '<X>Lexer.h'.
+# speedy-antlr-tool 1.4.3's shared support library leaks the whole translated parse
+# tree on every parse. Translator::convert_ctx() reassigns its `stop` pointer once
+# per child but releases it only once at the end, so every token except the last
+# keeps a stray reference; in the rule branch the new reference returned by
+# PyObject_GetAttrString() is dropped on the floor as well. Measured on a 2 MB
+# input: RSS grew ~115 MB per parse without bound (272 MB -> 861 MB over six
+# parses) until the kernel killed the process. With this patch RSS is flat.
+#
+# generate() re-emits speedy_antlr.cpp from the tool's template, so the fix has to
+# live here rather than as an edit to the generated file.
+SUPPORT_LIBRARY_PATCHES = [
+    ('convert_ctx() releases the previous `stop` (terminal branch)', [
+        ('            if(token->getType() != antlr4::IntStream::EOF) {\n'
+         '                // Always set stop to current token\n'
+         '                stop = py_token;\n'
+         '                Py_INCREF(stop);\n'
+         '            }',
+         '            if(token->getType() != antlr4::IntStream::EOF) {\n'
+         '                // Always set stop to current token\n'
+         '                Py_XDECREF(stop);  // wwPDB: release the previous stop, else every\n'
+         '                                   // token but the last leaks one reference\n'
+         '                stop = py_token;\n'
+         '                Py_INCREF(stop);\n'
+         '            }'),
+    ]),
+    ('convert_ctx() releases the previous `stop` and unused lookups (rule branch)', [
+        ('            if(!start || start==Py_None) {\n'
+         '                start = PyObject_GetAttrString(py_child, "start");\n'
+         '            }\n'
+         '            PyObject *tmp_stop = PyObject_GetAttrString(py_child, "stop");\n'
+         '            if (tmp_stop && tmp_stop!=Py_None) stop = tmp_stop;',
+         '            if(!start || start==Py_None) {\n'
+         '                Py_XDECREF(start);  // wwPDB: start may hold a reference to None\n'
+         '                start = PyObject_GetAttrString(py_child, "start");\n'
+         '                if (!start) PyErr_Clear();\n'
+         '            }\n'
+         '            PyObject *tmp_stop = PyObject_GetAttrString(py_child, "stop");\n'
+         '            if (tmp_stop && tmp_stop!=Py_None) {\n'
+         '                Py_XDECREF(stop);  // wwPDB: release the previous stop\n'
+         '                stop = tmp_stop;\n'
+         '            } else {\n'
+         '                Py_XDECREF(tmp_stop);  // wwPDB: unused new reference\n'
+         '                if (!tmp_stop) PyErr_Clear();\n'
+         '            }'),
+    ]),
+]
+
 BORROWED_LEXER_CPP_PATCHES = [
     ('the generated C++ references the borrowed lexer', [
         ('#include "%(assumedLexer)s.h"', '#include "%(lexer)s.h"'),
@@ -359,6 +406,15 @@ def generate(spec: GrammarSpec) -> dict:
             'sources': generatedSources(spec)}
 
 
+def patchSupportLibrary() -> None:
+    """ Fix the reference leaks in the shared speedy_antlr.cpp support library.
+        Applied once per run; every accelerator links the same copy.
+    """
+
+    applyPatches(os.path.join(CPP_SRC_DIR, 'speedy_antlr.cpp'), SUPPORT_LIBRARY_PATCHES, {})
+    print('\nspeedy_antlr.cpp: parse-tree reference leaks patched')
+
+
 def writeManifest(entries: list) -> None:
     """ Record the built accelerators for setup.py, which must not depend on this
         script (the container deletes tools/ after building).
@@ -418,7 +474,9 @@ def main() -> int:
                      f'known: {", ".join(sorted(grammars))}')
 
     fetchCppRuntime()
-    writeManifest([generate(grammars[name]) for name in names])
+    entries = [generate(grammars[name]) for name in names]
+    patchSupportLibrary()
+    writeManifest(entries)
 
     print('\nNow build the accelerators:\n'
           '  WWPDB_NMR_BUILD_SPEEDY_ANTLR=1 python setup.py build_clib build_ext --inplace -j $(nproc)')

--- a/wwpdb/utils/nmr/cpp_src/speedy_antlr.cpp
+++ b/wwpdb/utils/nmr/cpp_src/speedy_antlr.cpp
@@ -162,6 +162,8 @@ PyObject* Translator::convert_ctx(
             }
             if(token->getType() != antlr4::IntStream::EOF) {
                 // Always set stop to current token
+                Py_XDECREF(stop);  // wwPDB: release the previous stop, else every
+                                   // token but the last leaks one reference
                 stop = py_token;
                 Py_INCREF(stop);
             }
@@ -181,10 +183,18 @@ PyObject* Translator::convert_ctx(
 
             // Get start/stop
             if(!start || start==Py_None) {
+                Py_XDECREF(start);  // wwPDB: start may hold a reference to None
                 start = PyObject_GetAttrString(py_child, "start");
+                if (!start) PyErr_Clear();
             }
             PyObject *tmp_stop = PyObject_GetAttrString(py_child, "stop");
-            if (tmp_stop && tmp_stop!=Py_None) stop = tmp_stop;
+            if (tmp_stop && tmp_stop!=Py_None) {
+                Py_XDECREF(stop);  // wwPDB: release the previous stop
+                stop = tmp_stop;
+            } else {
+                Py_XDECREF(tmp_stop);  // wwPDB: unused new reference
+                if (!tmp_stop) PyErr_Clear();
+            }
         } else {
             PyErr_SetString(PyExc_RuntimeError, "Unknown child type");
             throw PythonException();


### PR DESCRIPTION
speedy-antlr-tool 1.4.3's Translator::convert_ctx() leaks the whole translated parse tree on every parse. It reassigns its `stop` pointer once per child but releases it only once at the end, so every token except the last keeps a stray reference; in the rule branch the new reference returned by PyObject_GetAttrString() is dropped on the floor as well.

Repeating one parse in a single process, RSS grew without bound:

  XplorMR,   0.5 MB input:  136 MB -> 346 MB over 6 parses (+41 MB/parse)
  NmrPipeCS, 2.0 MB input:  272 MB -> 861 MB over 6 parses (+115 MB/parse)

which is enough for a test run that parses many restraint files in one process to be OOM-killed. With this patch RSS is flat (154 MB after 6 parses of the 2 MB input; the pure-Python control was flat all along).

Peak RSS per parse is unchanged (288 MB for that input) - that is structural, since the C++ tree and the materialized Python tree necessarily coexist.

The fix lives in the generator's patch list rather than as an edit to the generated file, because generate() re-emits speedy_antlr.cpp from the tool's template on every run. Applied once per invocation and idempotent, with the same exact-match assertions as the other patches.

Verified after rebuilding all 42 accelerators: 42/42 load, the parse-level and reader-level A/B suites pass (trees field-for-field, both syntax-error streams, both prediction modes), and test_daother_7871 still produces a report identical to the pre-fix accelerated run.

Reported upstream at amykyta3/speedy-antlr-tool.